### PR TITLE
Better cache performance

### DIFF
--- a/src/trustchain/trustchain.py
+++ b/src/trustchain/trustchain.py
@@ -737,6 +737,7 @@ class TrustChain:
             if b.hash == tx.other_half.compact.hash:
                 assert b.seq == tx.other_half.seq
                 self.my_chain.set_validity(seq, ValidityState.Valid)
+                logging.info("TC: verified {}".format(encode_n(self.my_chain.chain[seq].hash)))
                 if use_cache:
                     updated = self._cache_compact_blocks(tx.inner.counterparty, compact_blocks)
                     if updated:
@@ -795,6 +796,8 @@ class TrustChain:
         this function attempts to filter these cases.
         :return: 
         """
+        if self.latest_cp.round < 2:
+            return []
         max_h = self.my_chain.get_cp_of_round(self.latest_cp.round - 1).seq
         txs = filter(lambda _tx: _tx.seq < max_h and _tx.request_sent_r < self.latest_round,
                      self.my_chain.get_unknown_txs())

--- a/src/trustchain/trustchain_runner.py
+++ b/src/trustchain/trustchain_runner.py
@@ -325,9 +325,7 @@ class TrustChainRunner:
         assert isinstance(resp, ValidationResp)
         logging.debug("TC: received validation resp from {}, {}".format(b64encode(remote_vk), resp))
 
-        res = self.tc.verify_tx(resp.seq, resp.pieces)
-        if res == ValidityState.Valid:
-            logging.info("TC: verified {}".format(encode_n(self.tc.my_chain.chain[resp.seq].hash)))
+        self.tc.verify_tx(resp.seq, resp.pieces)
 
     def handle(self, msg, remote_vk):
         # type: (Union[TxReq, TxResp]) -> None

--- a/tests/test_trustchain.py
+++ b/tests/test_trustchain.py
@@ -308,9 +308,15 @@ def test_validation(seq, n_cp, n_tx, expected):
     assert tc_s.verify_tx(seq, resp) == expected
 
     if expected == ValidityState.Valid:
-        assert len(tc_s.get_verifiable_txs()) == len(is_unknowns) - 1
-        assert tc_r.vk in tc_s._other_chains
-        assert set(tc_s._other_chains[tc_r.vk]).issuperset(resp)
+        # when we do one validation, everything that's in the cache also gets validated, thus - n_tx
+        assert len(tc_s.get_verifiable_txs()) == len(is_unknowns) - n_tx
 
+        # the cache should have an entry for the receiving node
+        assert tc_r.vk in tc_s._other_chains
+
+        # the response must be in the cache
+        assert set(tc_s._other_chains[tc_r.vk]) >= set(resp)
+
+        # if we load the cache again, it should be the initial response
         assert tc_s.load_cache_for_verification(seq) == resp
 


### PR DESCRIPTION
Use cache to validate immediately after receiving a new chain segment